### PR TITLE
Improve QueryGenerator and QueryExecutor

### DIFF
--- a/porthole/connections.py
+++ b/porthole/connections.py
@@ -57,6 +57,9 @@ class ConnectionManager():
         else:
             return None
 
+    def commit(self):
+        self.conn.connection.commit()
+
     def __enter__(self):
         self.connect()
         return self


### PR DESCRIPTION
Extract result fetching into a staticmethod of QueryGenerator class, and only fetch when there are rows available. This allows QueryGenerator to be used for the execution of SQL which does not return rows (e.g. update, truncate, etc).

Modify QueryExecutor so that each instance is not restricted to just one query - within context of a given connection, can execute an arbitrary number of statements.

Add commit helper method to ConnectionManager and QueryExecutor.