### PR TITLE
Added read-write for excel reports.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,7 @@ dependencies:
   - pymysql
   - psycopg2
   - xlsxwriter
+  - openpyxl=2.6.2
   - SQLAlchemy
   - pytz
-  - pip:
-    - flask-bootstrap==3.3.7.1
-    - Flask-WTF==0.14.2
-    - Flask==0.12.2
+

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,8 @@ dependencies:
   - pymysql
   - psycopg2
   - xlsxwriter
-  - openpyxl=2.6.2
+  - openpyxl=2.6.2  #this library allows for editing of existing Excel files
+  - lxml            #this library speeds up openpyxl
   - SQLAlchemy
   - pytz
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,8 @@ dependencies:
   - psycopg2
   - xlsxwriter
   - openpyxl=2.6.2  #this library allows for editing of existing Excel files
-  - lxml            #this library speeds up openpyxl
   - SQLAlchemy
   - pytz
+  - pip:
+    - lxml            #this library speeds up openpyxl
 

--- a/porthole/__init__.py
+++ b/porthole/__init__.py
@@ -10,7 +10,7 @@ try:
     from .reports import BasicReport, GenericReport, ReportRunner
     from .queries import QueryExecutor, QueryGenerator, QueryReader, QueryResult
     from .workflows import SimpleWorkflow
-    from .xlsx import WorkbookBuilder
+    from .xlsx import WorkbookBuilder, WorkbookEditor
 except KeyError:
     print("Unable to import Porthole due to KeyError. Check config/config.ini.")
     print("{}: {}".format(sys.exc_info()[1].__doc__, sys.exc_info()[1]))

--- a/porthole/components.py
+++ b/porthole/components.py
@@ -1,5 +1,7 @@
 import os, sys
+from typing import Optional, Union
 from sqlalchemy import select
+import sqlalchemy
 from . import TimeHelper
 from .app import config
 from .models import (
@@ -11,8 +13,9 @@ from .models import (
 from .mailer import Mailer
 from .related_record import RelatedRecord
 from .queries import QueryGenerator
-from .xlsx import WorkbookBuilder
+from .xlsx import WorkbookBuilder, WorkbookEditor
 from .logger import PortholeLogger
+from .connections import ConnectionManager
 
 logger = PortholeLogger(name=__name__)
 
@@ -97,12 +100,11 @@ class ReportWriter(Loggable):
     def add_format(self, format_name, format_params):
         self.workbook_builder.add_format(format_name, format_params)
 
-    def execute_query(self, cm, query={}, sql=None, increment_counter=True):
+    def execute_query(self, cm: ConnectionManager, query={}, sql=None, increment_counter=True):
         """
         Args:
             cm              (ConnectionManager):
                             Object which contains connection to desired database.
-            sheet_name      (str): The name of the worksheet to be created.
             query           (dict): Optional. May contain filename and params for a query
                                 to be executed. If included, filename is required.
                     filename      (str): Name of file to be read without extension.
@@ -168,6 +170,63 @@ class ReportWriter(Loggable):
             worksheet_kwargs = {}
         results = self.execute_query(cm=cm, query=query, sql=sql, **query_kwargs)
         self.make_worksheet(sheet_name=sheet_name, query_results=results, **worksheet_kwargs)
+
+
+class ReportReadWriter(Loggable):
+
+    def __init__(self, report_filename: str
+                    , read_file_path: Optional[str]=None
+                    , write_file_path: Optional[str]=None
+                    , log_to=None):
+        self.report_filename = report_filename
+        if not read_file_path:
+            self.read_file_path = config['Default'].get('base_file_path')
+        if not write_file_path:
+            self.write_file_path = self.read_file_path
+        self.read_location = os.path.join(self.read_file_path, self.report_filename)
+        self.write_location = os.path.join(self.write_file_path, self.report_filename)
+        self.record_count = 0
+        super().__init__(log_to=log_to if log_to is not None else [])
+
+    def update_sheet_on_report_workbook(self, cm: ConnectionManager
+                                        , sheet_name: str
+                                        , query: Optional[dict]=None
+                                        , sql: Optional[str]=None
+                                        , query_kwargs: Optional[dict]=None
+                                        , save_as: Optional[str]=None) -> None:
+        if query is None:
+            query = {}
+        if query_kwargs is None:
+            query_kwargs = {}
+        if save_as:
+            self.write_location = os.path.join(self.write_file_path, save_as)
+        
+        results = self.execute_query(cm=cm, query=query, sql=sql, **query_kwargs)
+        formatted_results = results.as_list_of_tuples()
+        wb = WorkbookEditor(workbook_filename=self.read_location)
+        wb.replace_sheet_contents(sheet_name=sheet_name, data_rows=formatted_results)
+        wb.save_workbook(save_as=self.write_location)
+
+    def execute_query(self, cm: ConnectionManager
+                        , query: dict={}
+                        , sql: Union[str, sqlalchemy.sql.selectable.Select, None]=None
+                        , increment_counter: bool=True):
+        """
+        Executes SQL and returns QueryResult object, containing data and metadata.
+        """
+        filename = query.get('filename')
+        params = query.get('params')
+        q = QueryGenerator(cm=cm, filename=filename, params=params, sql=sql)
+        try:
+            results = q.execute()
+            if increment_counter:
+                self.record_count += results.result_count
+            return results
+        except:
+            error = "Unable to execute query {}".format(query.get('filename'))
+            logger.error(error)
+            self.log_error(error)
+
 
 
 class DatabaseLogger(Loggable):
@@ -306,3 +365,5 @@ The following errors were logged:\n""".format(self.report_title)
         for i, error in enumerate(self.error_log, 1):
             msg += str(i) + '. ' + error + '\n'
         return msg
+
+

--- a/porthole/components.py
+++ b/porthole/components.py
@@ -202,9 +202,8 @@ class ReportReadWriter(Loggable):
             self.write_location = os.path.join(self.write_file_path, save_as)
         
         results = self.execute_query(cm=cm, query=query, sql=sql, **query_kwargs)
-        formatted_results = results.as_list_of_tuples()
         wb = WorkbookEditor(workbook_filename=self.read_location)
-        wb.replace_sheet_contents(sheet_name=sheet_name, data_rows=formatted_results)
+        wb.replace_sheet_contents(sheet_name=sheet_name, data_rows=results.result_data, headers=results.field_names)
         wb.save_workbook(save_as=self.write_location)
 
     def execute_query(self, cm: ConnectionManager

--- a/porthole/queries.py
+++ b/porthole/queries.py
@@ -34,13 +34,6 @@ class QueryResult(object):
     def as_dict(self):
         raise DeprecationWarning("QueryResult.as_dict method is no longer available and will be removed.")
 
-    def as_list_of_tuples(self):
-        """Returns contents as list of tuples with headers as first item"""
-        data = [tuple(row.values()) for row in self.result_data]
-        headers = tuple(self.field_names)
-        data.insert(0, headers)
-        return data
-
     def write_to_json(self, filename):
         with open(filename, 'w') as f:
             json.dump(self.result_data, f, default=self.json_converter)

--- a/porthole/queries.py
+++ b/porthole/queries.py
@@ -34,6 +34,13 @@ class QueryResult(object):
     def as_dict(self):
         raise DeprecationWarning("QueryResult.as_dict method is no longer available and will be removed.")
 
+    def as_list_of_tuples(self):
+        """Returns contents as list of tuples with headers as first item"""
+        data = [tuple(row.values()) for row in self.result_data]
+        headers = tuple(self.field_names)
+        data.insert(0, headers)
+        return data
+
     def write_to_json(self, filename):
         with open(filename, 'w') as f:
             json.dump(self.result_data, f, default=self.json_converter)

--- a/porthole/xlsx.py
+++ b/porthole/xlsx.py
@@ -139,12 +139,17 @@ class WorkbookEditor(object):
         worksheet = self.workbook.create_sheet(sheet_name)
         for row in data_rows:
             worksheet.append(row)
+
+    def get_all_values(self, sheet_name: str) -> list:
+        rows = []
+        for row in self.workbook[sheet_name].values:
+            rows.append(row)
+        return rows
     
-    def save_workbook(self, save_as: str='') -> None:
-        try:
-            self.workbook.save(save_as)
-        except FileNotFoundError:
-            self.workbook.save(self.workbook_filename)
+    def save_workbook(self, save_as: str=None) -> None:
+        if save_as is None:
+            save_as=self.workbook_filename
+        self.workbook.save(save_as)
 
 
 def apply_column_rule(row, rule):

--- a/porthole/xlsx.py
+++ b/porthole/xlsx.py
@@ -134,11 +134,12 @@ class WorkbookEditor(object):
         self.workbook_filename = workbook_filename
         self.workbook = openpyxl.load_workbook(filename=workbook_filename)
 
-    def replace_sheet_contents(self, sheet_name: str, data_rows: list) -> None:
+    def replace_sheet_contents(self, sheet_name: str, data_rows: list, headers: list) -> None:
         del self.workbook[sheet_name]
         worksheet = self.workbook.create_sheet(sheet_name)
+        worksheet.append(headers)
         for row in data_rows:
-            worksheet.append(row)
+            worksheet.append(list(row))
 
     def get_all_values(self, sheet_name: str) -> list:
         rows = []

--- a/porthole/xlsx.py
+++ b/porthole/xlsx.py
@@ -1,5 +1,6 @@
 import datetime
 import xlsxwriter
+import openpyxl
 
 
 class WorkbookBuilder(object):
@@ -126,6 +127,24 @@ class WorkbookBuilder(object):
                 col_widths[i] = WorkbookBuilder.MAX_COLUMN_WIDTH
 
         return col_widths
+
+
+class WorkbookEditor(object):
+    def __init__(self, workbook_filename):
+        self.workbook_filename = workbook_filename
+        self.workbook = openpyxl.load_workbook(filename=workbook_filename)
+
+    def replace_sheet_contents(self, sheet_name: str, data_rows: list) -> None:
+        del self.workbook[sheet_name]
+        worksheet = self.workbook.create_sheet(sheet_name)
+        for row in data_rows:
+            worksheet.append(row)
+    
+    def save_workbook(self, save_as: str='') -> None:
+        try:
+            self.workbook.save(save_as)
+        except FileNotFoundError:
+            self.workbook.save(self.workbook_filename)
 
 
 def apply_column_rule(row, rule):

--- a/tests/test_WorkbookEditor.py
+++ b/tests/test_WorkbookEditor.py
@@ -1,0 +1,69 @@
+import os
+import datetime
+import unittest
+from porthole import config
+from porthole import WorkbookEditor
+import openpyxl
+
+class TestWorkbookEditor(unittest.TestCase):
+    """
+    report.workbook.worksheets()[0].name
+    sheetname_count - count of sheets
+    sheetnames - dictionary where keys are sheetnames
+    fileclosed - 1 if closed, 0 otherwise
+    """
+
+    def setUp(self):
+        self.test_workbook = openpyxl.Workbook()
+        self.test_sheet = self.test_workbook.active
+        self.test_sheet.title = 'test_sheet_1'
+        self.test_sheet['A1'] = 3.14
+        self.test_data = [('the', 'grand', 'old', 'duke', 'of', 'york'),('had', 'ten', 'thousand', 'men', 'he', 'marched')]
+        self.test_filename = 'testfile.xlsx'
+        self.test_workbook.save(filename = self.test_filename)
+
+    def tearDown(self):
+        os.remove(self.test_filename)
+
+    def test_initialize_workbook_editor(self):
+        # with correct filename
+        correct_wb = WorkbookEditor(workbook_filename = self.test_filename )
+        self.assertIsInstance(correct_wb, WorkbookEditor)
+
+        #with incorrect filename
+        try:
+            incorrect_wb = WorkbookEditor(workbook_filename = 'this_file_does_not_exist.xlsx')
+            raise Exception('This method should have raised FileNotFoundError.')
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            raise Exception('This method should have raised FileNotFoundError.  Instead it raised: {}'.format(e))
+
+    def test_replace_sheet_contents(self):
+        sheet_name = self.test_sheet.title
+        wb = WorkbookEditor(workbook_filename = self.test_filename)
+        wb.replace_sheet_contents(sheet_name=sheet_name, data_rows=self.test_data)
+        values = wb.get_all_values(sheet_name)
+        self.assertEqual(values, self.test_data)
+
+    def test_save_workbook(self):
+        wb = WorkbookEditor(workbook_filename = self.test_filename)
+        sheet_name = self.test_sheet.title
+
+        # with save_as defined
+        save_as = 'foo.xlsx'
+        wb.save_workbook(save_as=save_as)
+        wb2 = WorkbookEditor(workbook_filename = save_as)
+        values = wb.get_all_values(sheet_name)
+        self.assertEqual(values[0][0], 3.14)
+
+        # with save_as undefined
+        os.remove(self.test_filename)
+        wb.save_workbook()
+        wb2 = WorkbookEditor(workbook_filename = self.test_filename)
+        values = wb2.get_all_values(sheet_name)
+        self.assertEqual(values[0][0], 3.14)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Added the ReportReadWriter class to the components module.  Current functionality includes replacing a worksheet with new data, and saving the workbook under a new name.

Was able to test by executing this from python session:
```python
from porthole.connections import ConnectionManager as CM
cm = CM('VWTest')
cm = CM('datateamprod')
cm.connect()
from porthole.components import ReportReadWriter as RRW
sql = 'select 99 as foo, 100 as bar'
rrw = RRW(report_filename='test.xlsx')
rrw.update_sheet_on_report_workbook(cm=cm, sheet_name='data', sql=sql, save_as='test2.xlsx')
```
For the above to work you need the file "test.xlsx" with the worksheet "data" in wherever you've designated the base file path in the config file.