### PR TITLE
Logging Overhaul - Add Database Handler; Remove module-level loggers; Add Error Buffer

### DIFF
--- a/porthole/__init__.py
+++ b/porthole/__init__.py
@@ -7,7 +7,7 @@ try:
     from .filters import ResultFilter
     from .logger import PortholeLogger
     from .mailer import Mailer
-    from .related_record import RelatedRecord, ChildRecord
+    from .related_record import RelatedRecord
     from .reports import BasicReport, GenericReport, ReportRunner
     from .queries import QueryExecutor, QueryGenerator, QueryReader, QueryResult
     from .workflows import SimpleWorkflow

--- a/porthole/alerts.py
+++ b/porthole/alerts.py
@@ -11,7 +11,7 @@ class Alert(object):
         project_name = config['Default'].get('project', '<Unspecified Project>')
         mailer = Mailer()
         mailer.recipients = recipients or [config['Admin']['admin_email']]
-        mailer.subject = "{} ALERT: ".format(project_name.upper()) + subject
+        mailer.subject = f"{project_name.upper()} ALERT: {subject}"
         mailer.message = message
         self.mailer = mailer
 
@@ -36,13 +36,12 @@ def send_alert_on_exception(function_to_be_decorated):
     """Use as a decorator to ensure that an alert is sent for any unhandled exceptions."""
     @wraps(function_to_be_decorated)
     def decorated_function():
-        project_name = config['Default'].get('project', '<Unspecified Project>')
         calling_module = getattr(function_to_be_decorated, '__module__', '<Unspecified Module>')
         try:
             function_to_be_decorated()
         except Exception as error:
             alert = Alert(
-                subject="{} Unhandled Exception Notification: ".format(project_name) + calling_module,
+                subject=f"Unhandled Exception Notification: {calling_module}",
                 message=str(error)
             )
             logger.error("Unhandled exception in {} - sending alert message.".format(calling_module))

--- a/porthole/components.py
+++ b/porthole/components.py
@@ -14,60 +14,21 @@ from .queries import QueryGenerator
 from .xlsx import WorkbookBuilder
 from .logger import PortholeLogger
 
-logger = PortholeLogger(name=__name__)
 
-
-class Loggable(object):
-    """
-    Inherit from this class to implement basic error logging. If derived class
-    overrides __init__, it must invoke Loggable.__init__() or super().__init__().
-    Args:
-        log_to  (list): Specify where logged errors should go. Intended to route
-            errors from several different types of Loggable objects to one
-            place.
-    Usage
-
-    class Component(Loggable):
-        def __init__(self, log_to=[]):
-            super().__init__(log_to=log_to)
-
-    class Report(object):
-        def __init__(self):
-            self.error_log = []
-            self.component = Component(log_to=self.error_log)
-    """
-    def __init__(self, log_to=None):
-        self.error_log = log_to if log_to is not None else []
-
-    def log_error(self, msg=None):
-        """
-        Args:
-            msg (str) Optional. Appends msg and exception context to error_log
-                list as an attribute of the object.
-        """
-        if not hasattr(self, 'error_log'):
-            self.error_log = []
-        error_value = sys.exc_info()[1]
-        log_record = str(error_value) + ': ' + str(error_value.__doc__)
-        if msg:
-            log_record = msg + ': ' + log_record
-        self.error_log.append(log_record)
-
-
-class ReportWriter(Loggable):
+class ReportWriter:
     """
     The purpose of this class is to use the QueryGenerator and WorkbookBuilder
     together to make an Excel file and populate it with data.
     """
     #TODO: Think of a better name for this class.
 
-    def __init__(self, report_title, log_to=None):
+    def __init__(self, report_title, logger=None):
         self.report_title = report_title
         self.report_file = None
         self.file_path = config['Default'].get('base_file_path')
         self.workbook_builder = None
         self.record_count = 0
-        super().__init__(log_to=log_to if log_to is not None else [])
+        self.logger = logger or PortholeLogger(report_title)
 
     def build_file(self):
         """
@@ -83,8 +44,7 @@ class ReportWriter(Loggable):
             self.workbook_builder = WorkbookBuilder(filename=self.report_file)
         except:
             error = "Unable to build file for {}".format(self.report_title)
-            logger.error(error)
-            self.log_error(error)
+            self.logger.exception(error)
 
     def close_workbook(self):
         """
@@ -97,7 +57,7 @@ class ReportWriter(Loggable):
     def add_format(self, format_name, format_params):
         self.workbook_builder.add_format(format_name, format_params)
 
-    def execute_query(self, cm, query={}, sql=None, increment_counter=True):
+    def execute_query(self, cm, query=None, sql=None, increment_counter=True):
         """
         Args:
             cm              (ConnectionManager):
@@ -114,6 +74,8 @@ class ReportWriter(Loggable):
 
         Executes SQL and returns QueryResult object, containing data and metadata.
         """
+        if query is None:
+            query = {}
         filename = query.get('filename')
         params = query.get('params')
         q = QueryGenerator(cm=cm, filename=filename, params=params, sql=sql)
@@ -124,8 +86,7 @@ class ReportWriter(Loggable):
             return results
         except:
             error = "Unable to execute query {}".format(query.get('filename'))
-            logger.error(error)
-            self.log_error(error)
+            self.logger.exception(error)
 
     def make_worksheet(self, sheet_name, query_results, **kwargs):
         """Adds worksheet to workbook using provided query results."""
@@ -138,8 +99,7 @@ class ReportWriter(Loggable):
             )
         except:
             error = "Unable to add worksheet {}".format(sheet_name)
-            logger.error(error)
-            self.log_error(error)
+            self.logger.exception(error)
 
     def create_worksheet_from_query(self, cm, sheet_name, query=None, sql=None, query_kwargs=None, worksheet_kwargs=None):
         """
@@ -170,16 +130,16 @@ class ReportWriter(Loggable):
         self.make_worksheet(sheet_name=sheet_name, query_results=results, **worksheet_kwargs)
 
 
-class DatabaseLogger(Loggable):
+class DatabaseLogger:
     """
     Don't want to log if report not active,
     or if logging is not enabled.
     """
-    def __init__(self, cm, report_name, log_to=None, log_table='report_logs'):
+    def __init__(self, cm, report_name, log_table='report_logs', logger=None):
         self.cm = cm
         self.report_name = report_name
         self.log_table = log_table
-        super().__init__(log_to=log_to if log_to is not None else [])
+        self.logger = logger or PortholeLogger(report_name)
 
     def create_record(self):
         """
@@ -189,34 +149,59 @@ class DatabaseLogger(Loggable):
         """
         report_log = RelatedRecord(self.cm, self.log_table)
         try:
-            report_log.insert({'report_name': self.report_name,
-                                'started_at': TimeHelper.now(string=False)})
+            report_log.insert({
+                'report_name': self.report_name,
+                'started_at': TimeHelper.now(string=False)
+            })
         except:
-            self.log_error("Unable to create log record.")
+            self.logger.exception("Unable to create log record.")
         self.report_log = report_log
 
     def finalize_record(self):
         """Update log at conclusion of report execution to indicate success/failure."""
-        if self.error_log:
-            data_to_update = {'completed_at': TimeHelper.now(string=False),
-                                'success': 0,
-                                'error_detail': "; ".join(self.error_log)}
+        error_buffer = self.logger.error_buffer.buffer
+        if error_buffer:
+            data_to_update = {
+                'completed_at': TimeHelper.now(string=False),
+                'success': 0,
+                'error_detail': "; ".join([str(err) for err in error_buffer])
+            }
         else:
-            data_to_update = {'completed_at': TimeHelper.now(string=False),
-                                'success': 1}
+            data_to_update = {
+                'completed_at': TimeHelper.now(string=False),
+                'success': 1
+            }
         try:
             self.report_log.update(data_to_update)
         except:
-            self.log_error("Unable to finalize log record.")
+            self.logger.exception("Unable to finalize log record.")
 
 
-class ReportActiveChecker(Loggable):
+class NewDBLogger:
+    def __init__(self, cm, report_name, log_table, logger=None):
+        self.cm = cm
+        self.report_name = report_name
+        self.log_table = log_table
+        self.logger = logger or PortholeLogger(report_name)
 
-    def __init__(self, cm, report_name, log_to=None):
+    def create(self):
+        statement = self.log_table.insert().values({
+            "report_name": self.report_name,
+            "started_at": TimeHelper.now(string=False)
+        })
+        try:
+            self.cm.conn.execute(statement)
+        except:
+            self.logger.exception("Unable to create log record.")
+
+
+class ReportActiveChecker:
+
+    def __init__(self, cm, report_name, logger=None):
         self.cm = cm
         self.report_name = report_name
         self.active = False
-        super().__init__(log_to=log_to if log_to is not None else [])
+        self.logger = logger or PortholeLogger(report_name)
         self.check_if_active()
 
     def __bool__(self):
@@ -226,8 +211,11 @@ class ReportActiveChecker(Loggable):
         """Queries database to determine if the 'active' attribute for this report
         is set to 1 (active) or 0 (inactive).
         """
-        statement = select([automated_reports.c.active])\
-                        .where(automated_reports.c.report_name==self.report_name)
+        statement = select(
+            [automated_reports.c.active]
+        ).where(
+            automated_reports.c.report_name == self.report_name
+            )
         try:
             q = QueryGenerator(cm=self.cm, sql=statement)
             results = q.execute()
@@ -240,18 +228,17 @@ class ReportActiveChecker(Loggable):
                 f"Report <{self.report_name}> was not found in the {automated_reports.name} table. "
                 f"Ensure <{self.report_name}> matches a record in the table and try again."
             )
-            logger.error(error)
-            self.log_error(error)
+            self.logger.exception(error)
             raise Exception(error)
 
 
-class RecipientsChecker(Loggable):
-    def __init__(self, cm, report_name, log_to=None):
+class RecipientsChecker:
+    def __init__(self, cm, report_name, logger=None):
         self.cm = cm
         self.report_name = report_name
         self.to_recipients = []
         self.cc_recipients = []
-        super().__init__(log_to=log_to if log_to is not None else [])
+        self.logger = logger or PortholeLogger(report_name)
 
     def get_recipients(self):
         """Performs lookup in database for report recipients based on report name."""
@@ -271,21 +258,20 @@ class RecipientsChecker(Loggable):
                     self.cc_recipients.append(recipient.email_address)
         except:
             error = "Error getting recipients for {}".format(self.report_name)
-            logger.error(error)
-            self.log_error(error)
+            self.logger.exception(error)
         if not self.to_recipients:
             error = "No primary recipient found for {}".format(self.report_name)
-            logger.error(error)
+            self.logger.error(error)
             raise KeyError("No primary recipient found for {}".format(self.report_name))
         return self.to_recipients, self.cc_recipients
 
 
-class ReportErrorNotifier(object):
+class ReportErrorNotifier:
 
-    def __init__(self, report_title, error_log):
+    def __init__(self, report_title, error_buffer):
         self.report_title = report_title
         self.notification_recipient = config['Default'].get('notification_recipient')
-        self.error_log = error_log
+        self.error_buffer = error_buffer
         self.notified = False
 
     def send_log_by_email(self):
@@ -303,6 +289,6 @@ class ReportErrorNotifier(object):
 
 The following errors were logged:\n""".format(self.report_title)
         msg = msg.format(self.report_title)
-        for i, error in enumerate(self.error_log, 1):
-            msg += str(i) + '. ' + error + '\n'
+        for i, error in enumerate(self.error_buffer, 1):
+            msg += str(i) + '. ' + str(error) + '\n'
         return msg

--- a/porthole/components.py
+++ b/porthole/components.py
@@ -1,4 +1,4 @@
-import os, sys
+import os
 from sqlalchemy import select
 from . import TimeHelper
 from .app import config
@@ -78,7 +78,7 @@ class ReportWriter:
             query = {}
         filename = query.get('filename')
         params = query.get('params')
-        q = QueryGenerator(cm=cm, filename=filename, params=params, sql=sql)
+        q = QueryGenerator(cm=cm, filename=filename, params=params, sql=sql, logger=self.logger)
         try:
             results = q.execute()
             if increment_counter:
@@ -164,7 +164,7 @@ class DatabaseLogger:
             data_to_update = {
                 'completed_at': TimeHelper.now(string=False),
                 'success': 0,
-                'error_detail': "; ".join([str(err) for err in error_buffer])
+                'error_detail': "; ".join([str(err) for err in error_buffer])[:255]
             }
         else:
             data_to_update = {
@@ -217,7 +217,7 @@ class ReportActiveChecker:
             automated_reports.c.report_name == self.report_name
             )
         try:
-            q = QueryGenerator(cm=self.cm, sql=statement)
+            q = QueryGenerator(cm=self.cm, sql=statement, logger=self.logger)
             results = q.execute()
             if results.result_data[0]['active'] == 1:
                 self.active = True
@@ -249,7 +249,7 @@ class RecipientsChecker:
                         .join(automated_report_contacts))\
                         .where(automated_reports.c.report_name==self.report_name)
         try:
-            q = QueryGenerator(cm=self.cm, sql=statement)
+            q = QueryGenerator(cm=self.cm, sql=statement, logger=self.logger)
             results = q.execute()
             for recipient in results.row_proxies:
                 if recipient.recipient_type == 'to':

--- a/porthole/components.py
+++ b/porthole/components.py
@@ -140,6 +140,7 @@ class DatabaseLogger:
         self.report_name = report_name
         self.log_table = log_table
         self.logger = logger or PortholeLogger(report_name)
+        self.report_log = None
 
     def create_record(self):
         """
@@ -156,6 +157,7 @@ class DatabaseLogger:
         except:
             self.logger.exception("Unable to create log record.")
         self.report_log = report_log
+        self.logger.extra.update(report_log_id=report_log.primary_key)
 
     def finalize_record(self):
         """Update log at conclusion of report execution to indicate success/failure."""

--- a/porthole/contact_management.py
+++ b/porthole/contact_management.py
@@ -3,12 +3,11 @@ from porthole import ConnectionManager
 from .logger import PortholeLogger
 from porthole.models import automated_reports, automated_report_contacts, automated_report_recipients
 
-logger = PortholeLogger(name=__name__)
-
 
 class AutomatedReportContactManager(object):
     def __init__(self, database: str):
         self.database = database
+        self.logger = PortholeLogger(name=__name__)
 
     def execute_statement(self, statement: sa.sql.base.Executable):
         with ConnectionManager(self.database) as cm:
@@ -63,7 +62,7 @@ class AutomatedReportContactManager(object):
 
     def add_report(self, report_name: str, active: int = 1):
         if self.report_exists(report_name):
-            logger.warning(f"{report_name} already exists")
+            self.logger.warning(f"{report_name} already exists")
             return None
         self.create_record(
             table=automated_reports,
@@ -72,31 +71,31 @@ class AutomatedReportContactManager(object):
                 'active': active
             }
         )
-        logger.info(f"Report '{report_name}' created successfully")
+        self.logger.info(f"Report '{report_name}' created successfully")
 
     def report_is_active(self, report_name):
         return self.record_exists(automated_reports, {'report_name': report_name, 'active': 1})
 
     def activate_report(self, report_name):
         if self.report_is_active(report_name):
-            logger.warning(f"Report '{report_name}' is already active")
+            self.logger.warning(f"Report '{report_name}' is already active")
             return None
         self.update_record(automated_reports, {'report_name': report_name}, {'active': 1})
-        logger.info(f"Report '{report_name}' is now active")
+        self.logger.info(f"Report '{report_name}' is now active")
 
     def deactivate_report(self, report_name):
         if not self.report_is_active(report_name):
-            logger.warning(f"Report '{report_name}' is already inactive")
+            self.logger.warning(f"Report '{report_name}' is already inactive")
             return None
         self.update_record(automated_reports, {'report_name': report_name}, {'active': 0})
-        logger.info(f"Report '{report_name}' is now inactive")
+        self.logger.info(f"Report '{report_name}' is now inactive")
 
     def contact_exists(self, email_address: str):
         return self.record_exists(automated_report_contacts, {'email_address': email_address})
 
     def add_contact(self, last_name: str = None, first_name: str = None, email_address: str = None):
         if self.contact_exists(email_address):
-            logger.warning(f"Contact {last_name}, {first_name} ({email_address}) already exists ")
+            self.logger.warning(f"Contact {last_name}, {first_name} ({email_address}) already exists ")
             return None
         self.create_record(
             table=automated_report_contacts,
@@ -106,7 +105,7 @@ class AutomatedReportContactManager(object):
                 'email_address': email_address
             }
         )
-        logger.info(f"Contact {last_name}, {first_name} ({email_address}) created successfully")
+        self.logger.info(f"Contact {last_name}, {first_name} ({email_address}) created successfully")
 
     def report_recipient_exists(self, report_name: str, email_address: str):
         return self.record_exists(
@@ -121,7 +120,7 @@ class AutomatedReportContactManager(object):
         if recipient_type not in ['to', 'cc']:
             raise ValueError("Recipient type must be either `to` or `cc`.")
         if self.report_recipient_exists(report_name, email_address):
-            logger.warning(f"Recipient '{email_address}' already exists for report '{report_name}'")
+            self.logger.warning(f"Recipient '{email_address}' already exists for report '{report_name}'")
             return None
         self.create_record(
             table=automated_report_recipients,
@@ -131,11 +130,11 @@ class AutomatedReportContactManager(object):
                 'recipient_type': recipient_type
             }
         )
-        logger.info(f"{recipient_type} recipient '{email_address}' added successfully to report '{report_name}'")
+        self.logger.info(f"{recipient_type} recipient '{email_address}' added successfully to report '{report_name}'")
 
     def remove_report_recipient(self, report_name: str, email_address: str):
         if not self.report_recipient_exists(report_name, email_address):
-            logger.warning(f"Recipient '{email_address}' does not exist for report '{report_name}'")
+            self.logger.warning(f"Recipient '{email_address}' does not exist for report '{report_name}'")
             return None
         self.delete_record(
             table=automated_report_recipients,
@@ -144,4 +143,4 @@ class AutomatedReportContactManager(object):
                 'contact_id': self.get_record_id(automated_report_contacts, 'email_address', email_address),
             }
         )
-        logger.info(f"Recipient '{email_address}' removed successfully from report '{report_name}'")
+        self.logger.info(f"Recipient '{email_address}' removed successfully from report '{report_name}'")

--- a/porthole/logger.py
+++ b/porthole/logger.py
@@ -33,6 +33,7 @@ class PortholeLogger(object):
         self.date_format = datefmt
         self.formatter = None
         self.error_buffer = None
+        self.extra = {}
         self.log_to_file = config['Logging'].getboolean('log_to_file', False)
         self.logfile = logfile or config['Logging'].get('logfile', None)
         self.log_to_db = log_to_db
@@ -105,19 +106,19 @@ class PortholeLogger(object):
         self.logger.debug(msg, *args, **kwargs)
 
     def info(self, msg, *args, **kwargs):
-        self.logger.info(msg, *args, **kwargs)
+        self.logger.info(msg, *args, extra=self.extra, **kwargs)
 
     def warning(self, msg, *args, **kwargs):
-        self.logger.warning(msg, *args, **kwargs)
+        self.logger.warning(msg, *args, extra=self.extra, **kwargs)
 
     def error(self, msg, *args, **kwargs):
-        self.logger.error(msg, *args, **kwargs)
+        self.logger.error(msg, *args, extra=self.extra, **kwargs)
 
     def critical(self, msg, *args, **kwargs):
-        self.logger.critical(msg, *args, **kwargs)
+        self.logger.critical(msg, *args, extra=self.extra, **kwargs)
 
     def exception(self, msg, *args, **kwargs):
-        self.logger.exception(msg, *args, **kwargs)
+        self.logger.exception(msg, *args, extra=self.extra, **kwargs)
 
     def set_level(self, level):
         self.logger.setLevel(level)
@@ -139,6 +140,7 @@ class DatabaseHandler(logging.Handler):
         else:
             trace = None
         data = {
+            'report_log_id': record.__dict__.get('report_log_id'),
             'level_number': record.levelno,
             'level_name': record.levelname,
             'msg': record.msg,

--- a/porthole/logger.py
+++ b/porthole/logger.py
@@ -1,6 +1,10 @@
 import logging
+import traceback
+import warnings
 from logging.handlers import TimedRotatingFileHandler
+import sqlalchemy as sa
 from .app import config
+from .models import report_log_details
 
 
 class PortholeLogger(object):
@@ -10,25 +14,40 @@ class PortholeLogger(object):
     Set behavior in config.ini:
         log_to_file (bool): Whether to write log to file.
         logfile (str):      Name of file to write to.
+        logging_db (str):   Name of database connection to write to, if applicable.
     """
 
     DEFAULT_FORMAT = '%(levelname)s -- %(asctime)s -- %(name)s -- %(message)s'
     DEFAULT_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
-    def __init__(self, name, logfile=None, fmt=DEFAULT_FORMAT, datefmt=DEFAULT_DATE_FORMAT):
+    def __init__(
+            self,
+            name: str,
+            logfile: str = None,
+            log_to_db: bool = False,
+            log_table: sa.table = report_log_details,
+            fmt: str = DEFAULT_FORMAT,
+            datefmt: str = DEFAULT_DATE_FORMAT
+    ):
         self.log_format = fmt
         self.date_format = datefmt
         self.formatter = None
         log_to_file = config['Logging'].getboolean('log_to_file', False)
         self.logfile = logfile or config['Logging'].get('logfile', None)
+        self.log_table = log_table
+
         self.rotate_logs = config['Logging'].getboolean('rotate_logs', False)
 
         self.logger = logging.getLogger(name)
         self.logger.setLevel(logging.INFO)
         self.create_formatter()
         self.add_stream_handler()
+        self.error_buffer = ErrorBuffer()
+        self.logger.addHandler(self.error_buffer)
         if log_to_file:
             self.add_file_handler()
+        if log_to_db:
+            self.add_db_handler()
 
     def create_formatter(self):
         self.formatter = logging.Formatter(
@@ -48,6 +67,14 @@ class PortholeLogger(object):
             handler = logging.FileHandler(self.logfile)
             handler.setFormatter(self.formatter)
             self.logger.addHandler(handler)
+
+    def add_db_handler(self):
+        log_db = config['Logging'].get('logging_db')
+        if not log_db:
+            self.warning("log_to_db is set to true, but logging_db is not set. Will not log to database.")
+            return
+        handler = DBHandler(database=log_db, table=self.log_table)
+        self.logger.addHandler(handler)
 
     def add_rotating_file_handler(self):
         interval_type = config['Logging.get'].get('rotation_interval_type', 'h')
@@ -81,3 +108,43 @@ class PortholeLogger(object):
 
     def set_level(self, level):
         self.logger.setLevel(level)
+
+
+class DBHandler(logging.Handler):
+    def __init__(self, database=None, table: sa.Table = None):
+        logging.Handler.__init__(self)
+        self.database = database
+        self.table = table
+
+    def emit(self, record):
+        if record.exc_info:
+            trace = traceback.format_exc()
+        else:
+            trace = None
+        data = {
+            'level_number': record.levelno,
+            'level_name': record.levelname,
+            'msg': record.msg,
+            'logger': record.name,
+            'traceback': trace
+        }
+        self._log_record_to_db(data)
+
+    def _log_record_to_db(self, log_data: dict):
+        from .connections import ConnectionManager
+        statement = self.table.insert().values(**log_data)
+        try:
+            with ConnectionManager(self.database) as cm:
+                cm.conn.execute(statement)
+        except Exception as e:
+            warnings.warn(f"Exception when writing log to database: {e}")
+
+
+class ErrorBuffer(logging.handlers.BufferingHandler):
+    def __init__(self, capacity: int = 1024):
+        super().__init__(capacity=capacity)
+        self.setLevel(logging.ERROR)
+
+    @property
+    def empty(self):
+        return len(self.buffer) == 0

--- a/porthole/mailer.py
+++ b/porthole/mailer.py
@@ -12,13 +12,20 @@ from email.mime.text import MIMEText
 from .app import config
 from .logger import PortholeLogger
 
-logger = PortholeLogger(name=__name__)
-
 COMMASPACE = ', '
 
 
 class Mailer:
-    def __init__(self, recipients=None, cc_recipients=None, debug_mode=None, text_format='plain', **kwargs):
+    def __init__(
+            self,
+            recipients=None,
+            cc_recipients=None,
+            debug_mode=None,
+            text_format='plain',
+            logger=None,
+            **kwargs
+    ):
+        self.logger = logger or PortholeLogger(name=__name__)
         self.recipients = recipients or []
         self.cc_recipients = cc_recipients or []
         self.bcc_recipients = []
@@ -40,7 +47,7 @@ class Mailer:
 
     def send_email(self):
         if config['Email']['disabled'] == 'True':
-            logger.info("Email disabled - exiting mailer.")
+            self.logger.info("Email disabled - exiting mailer.")
             exit()
 
         # Create the enclosing (outer) message
@@ -76,13 +83,13 @@ class Mailer:
                     )
                     outer.attach(msg)
                 except Exception as e:
-                    logger.exception(e)
+                    self.logger.exception(e)
                     raise
 
         composed = outer.as_string()
 
         if self.debug_mode:
-            logger.info(f"""Debug mode active. Sending only to designated debug recipient(s).
+            self.logger.info(f"""Debug mode active. Sending only to designated debug recipient(s).
 
 Active report would have been sent to:
             "To" Recipients: {self.recipients}
@@ -105,9 +112,9 @@ Active report would have been sent to:
                            composed)
                 self.all_sent_to_recipients = all_recipients
                 s.close()
-                logger.info("Email with subject '{}...' sent to {} recipients".format(self.subject, len(all_recipients)))
+                self.logger.info("Email with subject '{}...' sent to {} recipients".format(self.subject, len(all_recipients)))
         except Exception as e:
-            logger.exception(e)
+            self.logger.exception(e)
             raise
 
 

--- a/porthole/models.py
+++ b/porthole/models.py
@@ -57,7 +57,7 @@ report_log_details = Table(
     'report_log_details',
     metadata,
     Column('id', Integer, primary_key=True),
-    Column('report_log_id', Integer),
+    Column('report_log_id', Integer, ForeignKey(report_logs.c.id)),
     Column('level_number', Integer),
     Column('level_name', String(64)),
     Column('logger', String(64)),

--- a/porthole/models.py
+++ b/porthole/models.py
@@ -1,5 +1,6 @@
 from .app import config
-from sqlalchemy import MetaData, ForeignKey, Table, Column, Integer, String, DateTime, Boolean, func
+from sqlalchemy import MetaData, ForeignKey, Table, Column, func
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 
 try:
     schema = config[config['Default']['database']]['schema']
@@ -8,41 +9,60 @@ except:
 
 metadata = MetaData(schema=schema)
 
-automated_reports = Table('automated_reports', metadata,
-                Column('report_id', Integer, primary_key=True),
-                Column('report_name', String(64), nullable=False),
-                Column('active', Integer),
-                Column('created_at', DateTime, server_default=func.now()),
-                Column('updated_at', DateTime, onupdate=func.now()),
-            )
+automated_reports = Table(
+    'automated_reports',
+    metadata,
+    Column('report_id', Integer, primary_key=True),
+    Column('report_name', String(64), nullable=False),
+    Column('active', Integer),
+    Column('created_at', DateTime, server_default=func.now()),
+    Column('updated_at', DateTime, onupdate=func.now()),
+)
 
-automated_report_contacts = Table('automated_report_contacts', metadata,
-                Column('contact_id', Integer, primary_key=True),
-                Column('last_name', String(64)),
-                Column('first_name', String(64)),
-                Column('email_address', String(64)),
-                Column('created_at', DateTime, server_default=func.now()),
-                Column('updated_at', DateTime, onupdate=func.now()),
-            )
+automated_report_contacts = Table(
+    'automated_report_contacts',
+    metadata,
+    Column('contact_id', Integer, primary_key=True),
+    Column('last_name', String(64)),
+    Column('first_name', String(64)),
+    Column('email_address', String(64)),
+    Column('created_at', DateTime, server_default=func.now()),
+    Column('updated_at', DateTime, onupdate=func.now()),
+)
 
-automated_report_recipients = Table('automated_report_recipients', metadata,
-                Column('recipient_id', Integer, primary_key=True),
-                Column('report_id', Integer, ForeignKey(automated_reports.c.report_id),
-                                                        nullable=False),
-                Column('contact_id', Integer, ForeignKey(automated_report_contacts.c.contact_id),
-                                                        nullable=False),
-                Column('recipient_type', String(10), nullable=False),
-                Column('created_at', DateTime, server_default=func.now()),
-                Column('updated_at', DateTime, onupdate=func.now()),
-            )
+automated_report_recipients = Table(
+    'automated_report_recipients',
+    metadata,
+    Column('recipient_id', Integer, primary_key=True),
+    Column('report_id', Integer, ForeignKey(automated_reports.c.report_id), nullable=False),
+    Column('contact_id', Integer, ForeignKey(automated_report_contacts.c.contact_id), nullable=False),
+    Column('recipient_type', String(10), nullable=False),
+    Column('created_at', DateTime, server_default=func.now()),
+    Column('updated_at', DateTime, onupdate=func.now()),
+)
 
-report_logs = Table('report_logs', metadata,
-                Column('id', Integer, primary_key=True),
-                Column('report_name', String(64), nullable=False),
-                Column('started_at', DateTime),
-                Column('completed_at', DateTime),
-                Column('success', Boolean),
-                Column('error_detail', String(255)),
-                Column('created_at', DateTime, server_default=func.now()),
-                Column('updated_at', DateTime, onupdate=func.now()),
-            )
+report_logs = Table(
+    'report_logs', metadata,
+    Column('id', Integer, primary_key=True),
+    Column('report_name', String(64), nullable=False),
+    Column('started_at', DateTime),
+    Column('completed_at', DateTime),
+    Column('success', Boolean),
+    Column('error_detail', String(255)),
+    Column('created_at', DateTime, server_default=func.now()),
+    Column('updated_at', DateTime, onupdate=func.now()),
+)
+
+report_log_details = Table(
+    'report_log_details',
+    metadata,
+    Column('id', Integer, primary_key=True),
+    Column('report_log_id', Integer),
+    Column('level_number', Integer),
+    Column('level_name', String(64)),
+    Column('logger', String(64)),
+    Column('msg', Text),
+    Column('traceback', Text),
+    Column('created_at', DateTime, server_default=func.now()),
+    Column('updated_at', DateTime, onupdate=func.now()),
+)

--- a/porthole/related_record.py
+++ b/porthole/related_record.py
@@ -1,11 +1,4 @@
-
-"""
-RelatedRecord.py
-Created by William McMonagle on 01/03/17.
-Contains classes to allow for inserting, tracking, and associating of new db log records
-with parent/child relationships.
-"""
-from sqlalchemy import Table, MetaData, ForeignKey
+from sqlalchemy import Table, MetaData
 
 
 class RelatedRecord(object):
@@ -15,10 +8,12 @@ class RelatedRecord(object):
     """
     def __init__(self, connection_manager, table):
         self.cm = connection_manager
-        self.table = Table(table,
-                            MetaData(schema=connection_manager.schema),
-                            autoload=True,
-                            autoload_with=connection_manager.engine)
+        self.table = Table(
+            table,
+            MetaData(schema=connection_manager.schema),
+            autoload=True,
+            autoload_with=connection_manager.engine
+        )
         self.primary_key_name = self.inspect_primary_key()
         self.primary_key = None
         self.inserted = False
@@ -41,59 +36,19 @@ class RelatedRecord(object):
             except:
                 raise
         else:
-            raise("Cannot perform insert - record already inserted.")
+            raise RuntimeError("Cannot perform insert - record already inserted.")
 
     def update(self, date_to_update):
         try:
             key_column = getattr(self.table.c, self.primary_key_name)
-            statement = self.table.update()\
-                                    .where(key_column==self.primary_key)\
-                                    .values(**date_to_update)
+            statement = self.table.update().where(
+                key_column == self.primary_key
+            ).values(**date_to_update)
             self.cm.conn.execute(statement)
             self.updated = True
         except:
             raise
 
-class ChildRecord(RelatedRecord):
-    """
-    A ChildRecord is the child of a RelatedRecord. Functionality is similar
-    except that ChildRecord is related to the parent through a foreign key.
-    If foreign key name is not provided, an attempt is made to inspect the
-    reflected table.
-    """
-    def __init__(self, connection_manager, table, parent, foreign_key_name=None):
-        super().__init__(connection_manager, table)
-        self.parent = parent
-        if foreign_key_name:
-            self.foreign_key_name = foreign_key_name
-        else:
-            self.foreign_key_name = self.inspect_foreign_key()
-        self.foreign_key = parent.primary_key
-
-    def inspect_foreign_key(self):
-        """
-        Examines table to determine name of foreign key to parent table; validates
-        name match between identified key and primary key of parent table.
-        """
-        parent_key = "{}.{}".format(self.parent.table.name, self.parent.primary_key_name)
-        fk_cols = [column for column in self.table.columns.values() if column.foreign_keys]
-        found_keys = []
-        for col in fk_cols:
-            found = False
-            for fk in col.foreign_keys:
-                if str(fk.column) == parent_key:
-                    found = True
-            if found:
-                found_keys.append(col.name)
-        if len(found_keys) == 1:
-            return found_keys[0]
-        else:
-            raise ValueError("Expected one foreign key, found {}".format(len(found_keys)))
-
-    def insert(self, data_to_insert):
-        "Add fk key/value to dict and insert record."
-        data_to_insert[self.foreign_key_name] = self.foreign_key
-        super().insert(data_to_insert)
 
 if __name__ == '__main__':
     pass

--- a/porthole/reports.py
+++ b/porthole/reports.py
@@ -1,7 +1,7 @@
 import os
 from inspect import getfullargspec
 from argparse import ArgumentParser
-# from .alerts import Alert
+from .alerts import Alert
 from .app import config
 from .connections import ConnectionPool
 from .mailer import Mailer

--- a/porthole/uploaders.py
+++ b/porthole/uploaders.py
@@ -7,8 +7,6 @@ except ImportError:
 from .app import config
 from .logger import PortholeLogger
 
-logger = PortholeLogger("porthole.Uploaders")
-
 
 class S3Uploader(object):
     def __init__(self, debug_mode: bool = False) -> None:
@@ -16,6 +14,7 @@ class S3Uploader(object):
             raise ModuleNotFoundError(
                 "boto3 is a required dependency to use the S3Uploader class, but is not currently installed."
             )
+        self.logger = PortholeLogger("porthole.Uploaders")
         self.debug_mode = debug_mode or config.getboolean('Debug', 'debug_mode')
         s3_profile = config['AWS']['S3']
         session_params = {
@@ -29,7 +28,7 @@ class S3Uploader(object):
 
     def upload_file(self, key: str, filename: str, bucket: str = None, s3config: TransferConfig = None) -> bool:
         if self.debug_mode:
-            logger.info(
+            self.logger.info(
                 f"Debug mode active. Would have uploaded {filename} to {bucket}/{key}."
             )
             return True
@@ -43,11 +42,11 @@ class S3Uploader(object):
             s3config = TransferConfig(multipart_threshold=8388608 * 6)
         try:
             self.session.upload_file(Bucket=bucket, Key=key, Filename=filename, Config=s3config)
-            logger.info(f"Uploaded {filename} to {bucket}/{key}")
+            self.logger.info(f"Uploaded {filename} to {bucket}/{key}")
             return True
         except FileNotFoundError:
-            logger.exception(f"Unable to upload {filename}. File not found.")
+            self.logger.exception(f"Unable to upload {filename}. File not found.")
             return False
         except Exception:
-            logger.exception("Exception occurred during upload.")
+            self.logger.exception("Exception occurred during upload.")
             raise

--- a/run_tests.py
+++ b/run_tests.py
@@ -59,20 +59,20 @@ def main():
 
     # Select all of your test classes here.
     test_classes_to_run = [
-        TestAutomatedReportContactManager,
-        TestConnectionManager,
-        TestSimpleWorkflow,
-        TestRelatedRecord,
-        TestBasicReport,
+        # TestAutomatedReportContactManager,
+        # TestConnectionManager,
+        # TestSimpleWorkflow,
+        # TestRelatedRecord,
+        # TestBasicReport,
         TestGenericReport,
-        TestMailer,
-        TestReportRunner,
-        TestQueries,
-        TestRowDict,
-        TestReportWriter,
-        TestReportActiveChecker,
-        TestResultFilter,
-        TestWorkbookBuilder
+        # TestMailer,
+        # TestReportRunner,
+        # TestQueries,
+        # TestRowDict,
+        # TestReportWriter,
+        # TestReportActiveChecker,
+        # TestResultFilter,
+        # TestWorkbookBuilder
     ]
 
     # Setup

--- a/run_tests.py
+++ b/run_tests.py
@@ -59,20 +59,20 @@ def main():
 
     # Select all of your test classes here.
     test_classes_to_run = [
-        # TestAutomatedReportContactManager,
-        # TestConnectionManager,
-        # TestSimpleWorkflow,
-        # TestRelatedRecord,
-        # TestBasicReport,
+        TestAutomatedReportContactManager,
+        TestConnectionManager,
+        TestSimpleWorkflow,
+        TestRelatedRecord,
+        TestBasicReport,
         TestGenericReport,
-        # TestMailer,
-        # TestReportRunner,
-        # TestQueries,
-        # TestRowDict,
-        # TestReportWriter,
-        # TestReportActiveChecker,
-        # TestResultFilter,
-        # TestWorkbookBuilder
+        TestMailer,
+        TestReportRunner,
+        TestQueries,
+        TestRowDict,
+        TestReportWriter,
+        TestReportActiveChecker,
+        TestResultFilter,
+        TestWorkbookBuilder
     ]
 
     # Setup

--- a/run_tests.py
+++ b/run_tests.py
@@ -35,13 +35,23 @@ def setup_test_db():
         test_metadata.create_all(cm.engine)
         create_fixtures(cm)
         cm.close()
+    if config[db]['rdbms'] == 'mysql':
+        with ConnectionManager(db) as cm:
+            metadata.create_all(cm.engine)
+            test_metadata.create_all(cm.engine)
+            create_fixtures(cm)
 
 
 def teardown_test_db():
+    db = config['Default']['database']
     try:
         os.unlink('test.db')
     except FileNotFoundError:
         pass
+    if config[db]['rdbms'] == 'mysql':
+        with ConnectionManager(db) as cm:
+            metadata.drop_all(cm.engine)
+            test_metadata.drop_all(cm.engine)
 
 
 def main():

--- a/tests/test_ConnectionManager.py
+++ b/tests/test_ConnectionManager.py
@@ -33,5 +33,5 @@ class TestConnectionManager(unittest.TestCase):
     def test_context_manager(self):
         with ConnectionManager(db='Test') as cm:
             self.assertFalse(cm.closed())
-            cm.conn.execute("select * from flarp;")
+            cm.conn.execute("select * from sys.flarp;")
         self.assertTrue(cm.closed())

--- a/tests/test_Queries.py
+++ b/tests/test_Queries.py
@@ -67,13 +67,13 @@ class TestQueries(unittest.TestCase):
         executor = QueryExecutor(db='Test')
         executor.create_database_connection()
         self.assertFalse(executor.cm.conn.closed)
-        result1 = executor.execute_query(sql='select * from flarp;')
+        result1 = executor.execute_query(sql='select * from sys.flarp;')
         self.assertIsInstance(result1, QueryResult)
         executor.close_database_connection()
         self.assertTrue(executor.cm.conn.closed)
         with QueryExecutor(db='Test') as qe:
             self.assertFalse(qe.cm.conn.closed)
-            result2 = qe.execute_query(sql='select * from flarp;')
+            result2 = qe.execute_query(sql='select * from sys.flarp;')
             self.assertIsInstance(result2, QueryResult)
 
 

--- a/tests/test_RelatedRecord.py
+++ b/tests/test_RelatedRecord.py
@@ -1,6 +1,5 @@
-import sys
 import unittest
-from porthole import config, RelatedRecord, ChildRecord, ConnectionManager
+from porthole import config, RelatedRecord, ConnectionManager
 
 
 class TestRelatedRecord(unittest.TestCase):
@@ -26,21 +25,6 @@ class TestRelatedRecord(unittest.TestCase):
         first_record, second_record = multiple_inserts(self.cm)
         self.assertEqual(first_record.primary_key, second_record.primary_key - 1)
 
-    def test_insert_parent_and_child(self):
-        """When provided valid parameters, related records should be inserted."""
-        parent_record, child_record = insert_parent_and_child(self.cm)
-        self.assertTrue(parent_record.inserted)
-        self.assertTrue(child_record.inserted)
-        self.assertEqual(parent_record.primary_key, child_record.foreign_key)
-
-    def test_insert_parent_and_children(self):
-        """When provided valid parameters, a record should be inserted with multiple children,
-        which have a common foreign key defining their relationship."""
-        parent, first_child, second_child = insert_parent_and_children(self.cm)
-        self.assertEqual(parent.primary_key, first_child.foreign_key)
-        self.assertEqual(first_child.foreign_key, second_child.foreign_key)
-        self.assertEqual(first_child.primary_key, second_child.primary_key - 1)
-
 
 def basic_insert_and_update(cm):
     record = RelatedRecord(cm, 'flarp')
@@ -48,12 +32,6 @@ def basic_insert_and_update(cm):
                         'bar': 123})
     return record
 
-def insert_parent_and_child(cm):
-    parent_record = RelatedRecord(cm, 'flarp')
-    parent_record.insert({'foo': 'foo flarp'})
-    child_record = ChildRecord(cm, 'florp', parent_record)
-    child_record.insert({'baz': 'foo bar baz'})
-    return parent_record, child_record
 
 def multiple_inserts(cm):
     first_record = RelatedRecord(cm, 'flarp')
@@ -64,18 +42,11 @@ def multiple_inserts(cm):
                         'bar': 456})
     return first_record, second_record
 
-def insert_parent_and_children(cm):
-    parent = RelatedRecord(cm, 'flarp')
-    parent.insert({'foo': 'Large Dog'})
-    first_child = ChildRecord(cm, 'florp', parent)
-    first_child.insert({'baz': 'Small Dog'})
-    second_child = ChildRecord(cm, 'florp', parent)
-    second_child.insert({'baz': 'Tiny Dog'})
-    return parent, first_child, second_child
 
 def run():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestRelatedRecord)
     unittest.TextTestRunner(verbosity=3).run(suite)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_Reports.py
+++ b/tests/test_Reports.py
@@ -129,7 +129,7 @@ class TestGenericReport(unittest.TestCase):
         report.build_file()
         report.create_worksheet_from_query(query={'filename': 'does_not_exist'},
                                             sheet_name='Sheet1')
-        self.assertFalse(report.error_log == [])
+        self.assertFalse(report.logger.error_buffer.empty)
         report.db_logger.finalize_record()
 
     def test_send_failure_notification_on_error(self):
@@ -142,7 +142,7 @@ class TestGenericReport(unittest.TestCase):
         report.build_file()
         report.create_worksheet_from_query(sheet_name='Sheet1',
                                             sql=TEST_QUERY)
-        report.error_log.append("Forced error")
+        report.logger.error("Forced error")
         report.subject = "test_send_failure_notification_on_error"
         report.message = "test_send_failure_notification_on_error"
         report.execute()
@@ -179,7 +179,7 @@ class TestReportRunner(unittest.TestCase):
 
 
 
-TEST_QUERY = "select count(*) from flarp;"
+TEST_QUERY = "select count(*) from sys.flarp;"
 
 
 def run():

--- a/tests/test_Reports.py
+++ b/tests/test_Reports.py
@@ -54,26 +54,26 @@ class TestGenericReport(unittest.TestCase):
 
     def test_logging(self):
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active'
+        )
         self.assertFalse(report.email_sent)
         self.assertIsNotNone(report.db_logger)
 
     def test_disable_logging(self):
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                , logging_enabled=False
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active',
+            logging_enabled=False
+        )
         self.assertFalse(hasattr(report, 'report_log'))
         self.assertIsNone(report.db_logger)
 
     def test_send_email(self):
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active'
+        )
         report.send_email = MethodType(mocked_send_email, report)
         report.get_recipients()
         report.subject = "test_send_email"
@@ -86,9 +86,9 @@ class TestGenericReport(unittest.TestCase):
     def test_send_if_blank(self):
         self.assertTrue(True)
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active'
+        )
         report.send_if_blank = False
         report.build_file()
         report.send_email = MethodType(mocked_send_email, report)
@@ -109,33 +109,40 @@ class TestGenericReport(unittest.TestCase):
         """Should log an error if attempt to instantiate report that doesn't exist"""
         with self.assertRaises(Exception) as context:
             report = GenericReport(
-                                    report_name='does_not_exist'
-                                    , report_title='Does Not Exist'
-                                    )
+                report_name='does_not_exist',
+                report_title='Does Not Exist'
+            )
         self.assertTrue("Report <does_not_exist> was not found" in str(context.exception))
 
     def test_non_existent_query_raises_error(self):
         """Should raise an error if attempt to run query that doesn't exist"""
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active',
+            logger_name="test_non_existent_query_raises_error"
+        )
         report.build_file()
-        report.create_worksheet_from_query(query={'filename': 'does_not_exist'},
-                                            sheet_name='Sheet1')
+        report.create_worksheet_from_query(
+            query={'filename': 'does_not_exist'},
+            sheet_name='Sheet1'
+        )
+
         self.assertFalse(report.logger.error_buffer.empty)
         report.db_logger.finalize_record()
 
     def test_send_failure_notification_on_error(self):
         """On error, should send failure notification and should not send report."""
         report = GenericReport(
-                                report_name='test_report_active'
-                                , report_title='Test Report - Active'
-                                )
+            report_name='test_report_active',
+            report_title='Test Report - Active',
+            logger_name="test_send_failure_notification_on_error"
+        )
         report.send_failure_notification = MethodType(mocked_send_failure_notification, report)
         report.build_file()
-        report.create_worksheet_from_query(sheet_name='Sheet1',
-                                            sql=TEST_QUERY)
+        report.create_worksheet_from_query(
+            sheet_name='Sheet1',
+            sql=TEST_QUERY
+        )
         report.logger.error("Forced error")
         report.subject = "test_send_failure_notification_on_error"
         report.message = "test_send_failure_notification_on_error"
@@ -171,14 +178,13 @@ class TestReportRunner(unittest.TestCase):
         self.assertTrue(parsed.debug_mode)
 
 
-
-
 TEST_QUERY = "select count(*) from sys.flarp;"
 
 
 def run():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestGenericReport)
     unittest.TextTestRunner(verbosity=3).run(suite)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_Reports.py
+++ b/tests/test_Reports.py
@@ -8,12 +8,6 @@ Test email is not sent on failure.
 from types import MethodType
 import unittest
 from porthole import config, BasicReport, GenericReport, ReportRunner
-import pickle
-
-
-def pickle_object(obj, filename):
-    with open(filename, 'wb') as output:
-        pickle.dump(obj, output, pickle.HIGHEST_PROTOCOL)
 
 
 def mocked_send_email(self):

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -23,7 +23,7 @@ class TestReportWriter(unittest.TestCase):
         os.unlink(writer.report_file)
 
     def test_create_worksheet(self):
-        writer = ReportWriter("Test Report")
+        writer = ReportWriter("Test Report 2")
         writer.build_file()
         self.assertEqual(writer.record_count, 0)
         test_query = TEST_QUERY.format(self.cm.schema)
@@ -33,8 +33,8 @@ class TestReportWriter(unittest.TestCase):
         self.assertTrue(writer.logger.error_buffer.empty)
 
     def test_invalid_sheet_name_raises_error(self):
-        "Should log an error if attempt to add worksheet with invalid name"
-        writer = ReportWriter("Test Report")
+        """Should log an error if attempt to add worksheet with invalid name"""
+        writer = ReportWriter("Test Report 3")
         writer.build_file()
         test_query = TEST_QUERY.format(self.cm.schema)
         writer.create_worksheet_from_query(self.cm, "sheet/1", sql=test_query)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -30,7 +30,7 @@ class TestReportWriter(unittest.TestCase):
         writer.create_worksheet_from_query(self.cm, "sheet1", sql=test_query)
         writer.close_workbook()
         self.assertTrue(writer.record_count > 0)
-        self.assertFalse(writer.error_log)
+        self.assertTrue(writer.logger.error_buffer.empty)
 
     def test_invalid_sheet_name_raises_error(self):
         "Should log an error if attempt to add worksheet with invalid name"
@@ -39,7 +39,7 @@ class TestReportWriter(unittest.TestCase):
         test_query = TEST_QUERY.format(self.cm.schema)
         writer.create_worksheet_from_query(self.cm, "sheet/1", sql=test_query)
         writer.close_workbook()
-        self.assertTrue(writer.error_log)
+        self.assertFalse(writer.logger.error_buffer.empty)
 
 
 class TestReportActiveChecker(unittest.TestCase):


### PR DESCRIPTION
This PR involves a substantial overhaul of the PortholeLogger class, and a refactor of logging in general throughout the library.

Major Changes
- Add DatabaseHandler class
- Replace `Loggable` class with `ErrorBuffer` handler. Report instances now rely on `ErrorBuffer` to determine whether an exception has taken place (this effects `BasicReport`, `GenericReport`, and `ReportErrorNotifier`).
- Most classes now use instance-level PortholeLogger objects, rather than module-level. This allows for events associated with a given report instance to be integrated together.

Minor Changes
- Updates to indentation style for better readability (especially SQLAlchemy statements)
- Use of f-strings instead of `.format` in certain places
