### PR TITLE
Update recipient logging

### DIFF
--- a/porthole/components.py
+++ b/porthole/components.py
@@ -159,7 +159,7 @@ class DatabaseLogger:
 
     def finalize_record(self, all_recipients=None):
         """Update log at conclusion of report execution to indicate success/failure."""
-        all_recipients = all_recipients if all_recipients else []
+        all_recipients = "; ".join(all_recipients) if all_recipients else None
         error_buffer = self.logger.error_buffer.buffer
         if error_buffer:
             data_to_update = {
@@ -171,7 +171,7 @@ class DatabaseLogger:
             data_to_update = {
                 'completed_at': TimeHelper.now(string=False),
                 'success': 1,
-                'recipients': "; ".join(all_recipients)
+                'recipients': all_recipients
             }
         try:
             self.report_log.update(data_to_update)

--- a/porthole/reports.py
+++ b/porthole/reports.py
@@ -303,7 +303,7 @@ class GenericReport(BasicReport):
             if should_publish:
                 self.publish()
             if self.db_logger is not None:
-                recipients = self.all_recipients if should_publish else None
+                recipients = self.email.all_sent_to_recipients if self.email_sent else None
                 self.db_logger.finalize_record(recipients)
         if self.has_errors:
             self.send_failure_notification()

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -103,3 +103,12 @@ class TestDBLogger(unittest.TestCase):
         with QueryExecutor(default_db) as qe:
             result = qe.execute_query(sql=sql)
         self.assertEqual(result.result_data[0]['recipients'], "; ".join(test_recipients))
+
+    def test_blank_recipients(self):
+        db_logger = DatabaseLogger(cm=self.cm, report_name="TestDBLogger")
+        db_logger.create_record()
+        db_logger.finalize_record(all_recipients=None)
+        sql = f"select recipients from {self.cm.schema}.report_logs where id = {db_logger.report_log.primary_key}"
+        with QueryExecutor(default_db) as qe:
+            result = qe.execute_query(sql=sql)
+        self.assertIsNone(result.result_data[0]['recipients'])


### PR DESCRIPTION
Only log actual recipients when in debug mode. If no recipients,
write null instead of empty string. Only log recipients if email sent,
rather than if report should have been published (this also accounts for reports published to S3 rather than email).